### PR TITLE
Fix refresh controls and statistics calendar overflow

### DIFF
--- a/src/pages/history-page/history-page.component.html
+++ b/src/pages/history-page/history-page.component.html
@@ -1,6 +1,6 @@
 <div class="history-page-component">
     <div class="container">
-        <div class="o-grid o-grid--static">
+        <div class="o-grid o-grid--static page-header">
             <div class="o-grid__col" style="display: flex; align-items: center;">
                 <h3 class="u-mb-0"><i class="fa fa-history"></i> History</h3>
             </div>

--- a/src/pages/home-page/home-page.component.html
+++ b/src/pages/home-page/home-page.component.html
@@ -1,7 +1,7 @@
 <div class="home-page-component">
     <div class="container">
 
-        <div class="o-grid o-grid--static">
+        <div class="o-grid o-grid--static page-header">
             <div class="o-grid__col" style="display: flex; align-items: center;">
                 <h3 class="u-mb-0"><i class="fa fa-home"></i> Home</h3>
             </div>

--- a/src/pages/statistics-page/statistics-page.component.html
+++ b/src/pages/statistics-page/statistics-page.component.html
@@ -129,76 +129,50 @@
             </div>
         }
         @if (!calendarStatsLoading) {
-            <div class="o-grid">
-                <div class="o-grid__col">
-                    <div style="text-align:center;" class="u-mt-3">
+            <section class="analytics-card calendar-card u-mt-3">
+                <div class="analytics-card__header">
+                    <div>
+                        <span class="analytics-card__eyebrow">Daily activity</span>
+                        <h4>Watch history</h4>
+                    </div>
+                    <span class="calendar-card__period">
                         {{ startDate | date:'MMM' }} {{ startDate.getFullYear() }} - {{ endDate | date:'MMM' }} {{ endDate.getFullYear() }}
-                    </div>
-                    <div class="o-grid u-mt-2 calendar-scroll">
-                        <div class="o-grid__col">
-                            <div class="calendar-stats__days">
-                                <div class="calendar-stats__day">
-                                    Mon
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Tue
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Wed
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Thu
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Fri
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Sat
-                                </div>
-                                <div class="calendar-stats__day">
-                                    Sun
-                                </div>
-                            </div>
-                        </div>
-                        <div class="o-grid__col">
-                            <div class="calendar-stats__months">
-                                @for (month of calendarItemsMonths; track month) {
-                                    <div class="calendar-stats__month">
-                                        {{ month | date:'MMM' }}
-                                    </div>
-                                }
-                            </div>
-                            <div class="calendar-stats">
-                                @for (media of calendarItems; track media) {
-                                    <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, {{ media.value > 0 ? generateCalenderItemColour(media.value) : '' }})"
-                                         title="{{ media.key }} - {{ media.value }}"></div>
-                                }
-                            </div>
+                    </span>
+                </div>
+                <div class="calendar-scroll" aria-label="365-day watch history">
+                    <div class="calendar-scroll__labels">
+                        <div class="calendar-stats__days">
+                            <div class="calendar-stats__day">Mon</div>
+                            <div class="calendar-stats__day">Tue</div>
+                            <div class="calendar-stats__day">Wed</div>
+                            <div class="calendar-stats__day">Thu</div>
+                            <div class="calendar-stats__day">Fri</div>
+                            <div class="calendar-stats__day">Sat</div>
+                            <div class="calendar-stats__day">Sun</div>
                         </div>
                     </div>
-                    <div style="text-align:center;" class="u-mt-1">
-                        <div class="calendar-stats__legend">
-                            <div class="">
-                                0
-                                <div class="calendar-stats__cell" style="background:rgba(255, 255, 255, 0.05)"></div>
-                            </div>
-                            <div class="">
-                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.25)"></div>
-                            </div>
-                            <div class="">
-                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.5)"></div>
-                            </div>
-                            <div class="">
-                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.75)"></div>
-                            </div>
-                            <div class="">
-                                {{ calendarMaxValue }}
-                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 1)"></div>
-                            </div>
+                    <div class="calendar-scroll__content">
+                        <div class="calendar-stats__months">
+                            @for (month of calendarItemsMonths; track month) {
+                                <div class="calendar-stats__month">{{ month | date:'MMM' }}</div>
+                            }
+                        </div>
+                        <div class="calendar-stats">
+                            @for (media of calendarItems; track media) {
+                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, {{ media.value > 0 ? generateCalenderItemColour(media.value) : '' }})"
+                                     title="{{ media.key }} - {{ media.value }}"></div>
+                            }
                         </div>
                     </div>
                 </div>
-            </div>
+                <div class="calendar-card__legend">
+                    <div>0 <div class="calendar-stats__cell" style="background:rgba(255, 255, 255, 0.05)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.25)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.5)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.75)"></div></div>
+                    <div>{{ calendarMaxValue }} <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 1)"></div></div>
+                </div>
+            </section>
         }
     </div>
 </div>

--- a/src/pages/statistics-page/statistics-page.component.scss
+++ b/src/pages/statistics-page/statistics-page.component.scss
@@ -70,6 +70,8 @@
         justify-content: flex-start;
         align-items: flex-start;
         align-content: flex-start;
+        width: max-content;
+        min-width: max-content;
         height: calc((15px + 4px) * 7);
 
         &__months {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -347,16 +347,31 @@ hr {
     height: 36px;
     min-height: 36px !important;
     padding: 0 !important;
+    box-sizing: border-box;
     place-items: center;
+    align-items: center;
+    justify-content: center;
     border: 1px solid var(--border-color) !important;
     border-radius: 10px;
     color: var(--text-color-alt) !important;
     cursor: pointer;
+    line-height: 1;
+    transform: none !important;
 
-    &:hover:not(:disabled) {
-        color: var(--text-color) !important;
-        transform: rotate(10deg);
+    i {
+        display: block;
+        margin: 0;
+        line-height: 1;
+        transform-origin: center;
+        transition: transform var(--transition-speed) ease, color var(--transition-speed) ease;
     }
+
+    &:hover:not(:disabled), &:active:not(:disabled) {
+        color: var(--text-color) !important;
+        transform: none !important;
+    }
+
+    &:hover:not(:disabled) i:not(.fa-spin) { transform: rotate(10deg); }
 }
 
 .details-toolbar .btn {
@@ -555,13 +570,58 @@ hr {
         }
     }
 
+    .calendar-card {
+        width: 100%;
+
+        &__period {
+            align-self: center;
+            color: var(--text-color-alt);
+            font-size: .72rem;
+            font-weight: 700;
+            letter-spacing: .04em;
+            text-align: right;
+        }
+
+        &__legend {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 14px;
+            margin-top: 16px;
+            color: var(--text-color-alt);
+            font-size: .7rem;
+
+            & > div {
+                display: flex;
+                align-items: center;
+                gap: 5px;
+            }
+
+            .calendar-stats__cell { flex: 0 0 auto; }
+        }
+    }
+
     .calendar-scroll {
-        max-width: 100%;
+        display: flex;
+        width: 100%;
+        min-width: 0;
         overflow-x: auto;
         overscroll-behavior-inline: contain;
+        scrollbar-color: rgba(151, 116, 245, .5) transparent;
 
-        & > .o-grid__col:last-child {
+        &__labels {
+            flex: 0 0 44px;
+            min-width: 44px;
+        }
+
+        &__content {
+            flex: 0 0 auto;
+            width: max-content;
             min-width: max-content;
+        }
+
+        @media(max-width: $mobile-width) {
+            &__labels { display: none; }
         }
     }
 


### PR DESCRIPTION
## Summary

- Center the refresh icon consistently in the Home, History, and Statistics page buttons.
- Keep the refresh button stationary on hover and rotate only the sync icon.
- Move the 365-day watch history grid into a matching analytics card.
- Give the calendar an intrinsic-width content area with horizontal scrolling on smaller screens.
- Keep weekday labels aligned on larger screens and hide them cleanly on mobile.

## Validation

- `npm run build` ✅
- `npx tsc --noEmit -p tsconfig.app.json` ✅
- `git diff --check` ✅
- Existing Sass deprecation and bundle/component budget warnings remain.

No pull request template was present in the repository.

This pull request was created by an AI agent (OpenHands) on behalf of the user.