### PR TITLE
Improve chart interactions and refresh alignment

### DIFF
--- a/src/pages/statistics-page/statistics-page.component.html
+++ b/src/pages/statistics-page/statistics-page.component.html
@@ -57,10 +57,23 @@
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </div>
                     <div class="genre-chart">
-                        <div class="genre-chart__pie" [style.background]="genrePieStyle" role="img" aria-label="Genres watched pie chart"></div>
+                        <svg class="genre-chart__pie" viewBox="0 0 154 154" role="img" aria-label="Genres watched pie chart">
+                            @if (!genreSlices.length) {
+                                <circle cx="77" cy="77" r="69" class="genre-chart__pie-empty"></circle>
+                            }
+                            @for (slice of genreSlices; track slice.name) {
+                                <path class="genre-chart__slice" [class.is-hovered]="hoveredGenre?.name === slice.name"
+                                      [attr.d]="genreSlicePath(slice)" [attr.fill]="slice.color"
+                                      [attr.opacity]="hoveredGenre && hoveredGenre.name !== slice.name ? 0.42 : 1"
+                                      [attr.aria-label]="slice.name + ': ' + slice.value + ' watches, ' + (slice.percentage | number:'1.0-0') + '%'"
+                                      tabindex="0" role="button"
+                                      (mouseenter)="selectGenre(slice)" (mouseleave)="clearGenreSelection()"
+                                      (focus)="selectGenre(slice)" (blur)="clearGenreSelection()"></path>
+                            }
+                        </svg>
                         <div class="genre-chart__legend">
                             @for (slice of genreSlices; track slice.name) {
-                                <div class="genre-legend-item">
+                                <div class="genre-legend-item" (mouseenter)="selectGenre(slice)" (mouseleave)="clearGenreSelection()">
                                     <span class="genre-legend-item__swatch" [style.background]="slice.color"></span>
                                     <span>{{ slice.name }}</span>
                                     <strong>{{ slice.percentage | number:'1.0-0' }}%</strong>
@@ -69,6 +82,14 @@
                             @if (!genreSlices.length) {
                                 <span class="analytics-empty">No genre data yet.</span>
                             }
+                            <div class="genre-chart__detail" aria-live="polite">
+                                @if (hoveredGenre) {
+                                    <strong>{{ hoveredGenre.name }} · {{ hoveredGenre.value }} watches</strong>
+                                    <span>{{ hoveredGenre.percentage | number:'1.0-0' }}% of your watched titles</span>
+                                } @else if (genreSlices.length) {
+                                    <span>Hover a slice to explore its watch total.</span>
+                                }
+                            </div>
                         </div>
                     </div>
                 </section>
@@ -81,16 +102,24 @@
                         </div>
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </div>
-                    <div class="line-chart" role="img" aria-label="Line graph showing watches by time of day">
-                        <svg viewBox="0 0 720 220" preserveAspectRatio="none" aria-hidden="true">
+                    <div class="line-chart" role="group" aria-label="Line graph showing watches by time of day">
+                        <svg viewBox="0 0 720 220" aria-label="Watches by time of day">
                             <path class="line-chart__area" [attr.d]="timeOfDayChart.areaPath"></path>
                             <path class="line-chart__line" [attr.d]="timeOfDayChart.linePath"></path>
                             @for (point of timeOfDayChart.points; track point.x) {
-                                <circle class="line-chart__point" [attr.cx]="point.x" [attr.cy]="point.y" r="4">
-                                    <title>{{ point.label || 'Hour' }}: {{ formatChartValue(point.value) }} watches</title>
-                                </circle>
+                                <circle class="line-chart__point" [attr.cx]="point.x" [attr.cy]="point.y" r="4"
+                                        [attr.aria-label]="point.detailLabel + ': ' + point.value + ' watches'"
+                                        tabindex="0" role="img"
+                                        (mouseenter)="selectChartPoint('time', point)" (mouseleave)="clearChartPoint()"
+                                        (focus)="selectChartPoint('time', point)" (blur)="clearChartPoint()"></circle>
                             }
                         </svg>
+                        @if (hoveredChartPoint?.chart === 'time') {
+                            <div class="line-chart__tooltip" aria-live="polite">
+                                <strong>{{ hoveredChartPoint?.label }} · {{ hoveredChartPoint?.value }} watches</strong>
+                                <span>{{ hoveredChartPoint?.description }}</span>
+                            </div>
+                        }
                         <div class="line-chart__labels">
                             @for (point of timeOfDayChart.points; track point.x) {
                                 @if (point.label) {
@@ -109,16 +138,24 @@
                         </div>
                         <i class="fa fa-calendar-o" aria-hidden="true"></i>
                     </div>
-                    <div class="line-chart" role="img" aria-label="Line graph showing watches by day of the week">
-                        <svg viewBox="0 0 720 220" preserveAspectRatio="none" aria-hidden="true">
+                    <div class="line-chart" role="group" aria-label="Line graph showing watches by day of the week">
+                        <svg viewBox="0 0 720 220" aria-label="Watches by day of the week">
                             <path class="line-chart__area" [attr.d]="weekdayChart.areaPath"></path>
                             <path class="line-chart__line" [attr.d]="weekdayChart.linePath"></path>
                             @for (point of weekdayChart.points; track point.x) {
-                                <circle class="line-chart__point" [attr.cx]="point.x" [attr.cy]="point.y" r="4">
-                                    <title>{{ point.label }}: {{ formatChartValue(point.value) }} watches</title>
-                                </circle>
+                                <circle class="line-chart__point" [attr.cx]="point.x" [attr.cy]="point.y" r="4"
+                                        [attr.aria-label]="point.detailLabel + ': ' + point.value + ' watches'"
+                                        tabindex="0" role="img"
+                                        (mouseenter)="selectChartPoint('weekday', point)" (mouseleave)="clearChartPoint()"
+                                        (focus)="selectChartPoint('weekday', point)" (blur)="clearChartPoint()"></circle>
                             }
                         </svg>
+                        @if (hoveredChartPoint?.chart === 'weekday') {
+                            <div class="line-chart__tooltip" aria-live="polite">
+                                <strong>{{ hoveredChartPoint?.label }} · {{ hoveredChartPoint?.value }} watches</strong>
+                                <span>{{ hoveredChartPoint?.description }}</span>
+                            </div>
+                        }
                         <div class="line-chart__labels">
                             @for (point of weekdayChart.points; track point.x) {
                                 <span>{{ point.label }}</span>

--- a/src/pages/statistics-page/statistics-page.component.ts
+++ b/src/pages/statistics-page/statistics-page.component.ts
@@ -9,9 +9,17 @@ import { UserService } from '../../services/user-service/user.service';
 
 interface IChartPoint {
     label: string;
+    detailLabel: string;
     value: number;
     x: number;
     y: number;
+}
+
+interface IChartTooltip {
+    chart: 'time' | 'weekday';
+    label: string;
+    value: number;
+    description: string;
 }
 
 interface ILineChart {
@@ -26,6 +34,8 @@ interface IGenreSlice {
     value: number;
     percentage: number;
     color: string;
+    startAngle: number;
+    endAngle: number;
 }
 
 @Component({
@@ -48,8 +58,10 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
     public endDate: Date = new Date();
     public calendarMaxValue: number = 0;
     public genreSlices: IGenreSlice[] = [];
+    public hoveredGenre: IGenreSlice | null = null;
     public timeOfDayChart: ILineChart = this.emptyLineChart();
     public weekdayChart: ILineChart = this.emptyLineChart();
+    public hoveredChartPoint: IChartTooltip | null = null;
     public readonly timeOfDayLabels: string[] = ['12a', '3a', '6a', '9a', '12p', '3p', '6p', '9p'];
     public readonly weekdayLabels: string[] = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
@@ -146,20 +158,66 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
         }
 
         const total = visibleEntries.reduce((sum, [, value]) => sum + value, 0);
+        let startAngle = 0;
         return visibleEntries.map(([name, value], index) => {
             const percentage = total ? (value / total) * 100 : 0;
-            return { name, value, percentage, color: colors[index % colors.length] };
+            const slice = {
+                name,
+                value,
+                percentage,
+                color: colors[index % colors.length],
+                startAngle,
+                endAngle: startAngle + (percentage / 100) * 360,
+            };
+            startAngle = slice.endAngle;
+            return slice;
         });
     }
 
-    public get genrePieStyle(): string {
-        let offset = 0;
-        const stops = this.genreSlices.map((slice) => {
-            const start = offset;
-            offset += slice.percentage;
-            return `${slice.color} ${start}% ${offset}%`;
-        });
-        return `conic-gradient(${stops.join(', ') || 'rgba(255,255,255,.08) 0 100%'})`;
+    public genreSlicePath(slice: IGenreSlice): string {
+        const center = 77;
+        const radius = 69;
+        const startAngle = slice.startAngle - 90;
+        const endAngle = slice.endAngle - 90;
+        const start = this.polarPoint(center, center, radius, startAngle);
+        const end = this.polarPoint(center, center, radius, endAngle);
+        const span = slice.endAngle - slice.startAngle;
+        if (span >= 359.99) {
+            return `M ${center} ${center - radius} A ${radius} ${radius} 0 1 1 ${center} ${center + radius} A ${radius} ${radius} 0 1 1 ${center} ${center - radius} Z`;
+        }
+        return `M ${center} ${center} L ${start.x} ${start.y} A ${radius} ${radius} 0 ${span > 180 ? 1 : 0} 1 ${end.x} ${end.y} Z`;
+    }
+
+    public selectGenre(slice: IGenreSlice): void {
+        this.hoveredGenre = slice;
+    }
+
+    public clearGenreSelection(): void {
+        this.hoveredGenre = null;
+    }
+
+    public selectChartPoint(chart: 'time' | 'weekday', point: IChartPoint): void {
+        this.hoveredChartPoint = {
+            chart,
+            label: point.detailLabel,
+            value: point.value,
+            description: chart === 'time' ? 'Watches started during this time of day.' : 'Watches recorded on this day of the week.',
+        };
+    }
+
+    public clearChartPoint(): void {
+        this.hoveredChartPoint = null;
+    }
+
+    private polarPoint(centerX: number, centerY: number, radius: number, angle: number): { x: number; y: number } {
+        const radians = angle * Math.PI / 180;
+        return { x: centerX + radius * Math.cos(radians), y: centerY + radius * Math.sin(radians) };
+    }
+
+    private formatHourLabel(hour: number): string {
+        const suffix = hour >= 12 ? 'PM' : 'AM';
+        const displayHour = hour % 12 || 12;
+        return `${displayHour}:00 ${suffix}`;
     }
 
     private createLineChart(values: number[], labels: string[], labelStep: number): ILineChart {
@@ -170,6 +228,7 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
         const maxValue = Math.max(...values, 1);
         const points = values.map((value, index) => ({
             label: index % labelStep === 0 ? labels[index / labelStep] || '' : '',
+            detailLabel: values.length === 24 ? this.formatHourLabel(index) : labels[index] || `Day ${index + 1}`,
             value,
             x: left + (index / Math.max(values.length - 1, 1)) * (right - left),
             y: bottom - (value / maxValue) * (bottom - top),
@@ -181,10 +240,6 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
 
     private emptyLineChart(): ILineChart {
         return this.createLineChart([0, 0], ['', ''], 1);
-    }
-
-    public formatChartValue(value: number): string {
-        return value.toString();
     }
 
     private generateCalendarMatrix(): void {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -341,8 +341,19 @@ hr {
     }
 }
 
+.page-header {
+    align-items: center;
+
+    & > .o-grid__col--fixed {
+        display: flex;
+        flex: 0 0 36px;
+        align-items: center;
+        justify-content: flex-end;
+    }
+}
+
 .page-refresh {
-    display: grid !important;
+    display: inline-grid !important;
     width: 36px;
     height: 36px;
     min-height: 36px !important;
@@ -531,9 +542,34 @@ hr {
             border: 8px solid rgba(11, 13, 19, .55);
             border-radius: 50%;
             box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .12);
+            overflow: visible;
         }
 
+        &__slice {
+            cursor: pointer;
+            outline: none;
+            transition: opacity var(--transition-speed) ease, filter var(--transition-speed) ease;
+
+            &:hover, &:focus, &.is-hovered {
+                filter: brightness(1.18) drop-shadow(0 0 4px rgba(255, 255, 255, .24));
+            }
+        }
+
+        &__pie-empty { fill: rgba(255, 255, 255, .08); }
+
         &__legend { flex: 1; width: 100%; }
+
+        &__detail {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+            min-height: 34px;
+            margin-top: 12px;
+            color: var(--text-color-alt);
+            font-size: .7rem;
+
+            strong { color: var(--text-color); font-size: .76rem; }
+        }
     }
 
     .genre-legend-item {
@@ -559,7 +595,29 @@ hr {
 
         &__area { fill: rgba(151, 116, 245, .14); }
         &__line { fill: none; stroke: $brand-primary; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3; }
-        &__point { fill: $brand-primary; stroke: #171923; stroke-width: 2; }
+        &__point {
+            fill: $brand-primary;
+            stroke: #171923;
+            stroke-width: 2;
+            cursor: pointer;
+            outline: none;
+            vector-effect: non-scaling-stroke;
+            transition: filter var(--transition-speed) ease;
+
+            &:hover, &:focus { filter: drop-shadow(0 0 4px rgba(255, 255, 255, .48)); }
+        }
+
+        &__tooltip {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+            min-height: 34px;
+            margin: 7px 18px 0 38px;
+            color: var(--text-color-alt);
+            font-size: .7rem;
+
+            strong { color: var(--text-color); font-size: .76rem; }
+        }
 
         &__labels {
             display: flex;


### PR DESCRIPTION
## Summary

- Align the top-right refresh button and sync icon consistently within the button bounds.
- Prevent refresh-button hover transforms and keep hover rotation limited to the icon.
- Render line-chart points as round SVG circles without aspect-ratio distortion.
- Add visible hover and keyboard-focus details for line points, including the metric value and its meaning.
- Replace the CSS conic-gradient genre chart with interactive SVG slices.
- Highlight the active genre slice and show its watch total and percentage on hover or focus.

## Validation

- `npm run build` ✅
- `npx tsc --noEmit -p tsconfig.app.json` ✅
- `git diff --check` ✅
- Existing Sass deprecation and bundle/component budget warnings remain.
- Browser visual validation was unavailable because no browser session could be initialized.

No pull request template was present in the repository.

This pull request was created by an AI agent (OpenHands) on behalf of the user.