### PR TITLE
Improve daily activity and weekday analytics

### DIFF
--- a/src/pages/statistics-page/statistics-page.component.html
+++ b/src/pages/statistics-page/statistics-page.component.html
@@ -46,6 +46,65 @@
             </div>
         }
 
+        @if (!calendarStatsLoading) {
+            <section class="analytics-card calendar-card u-mt-3">
+                <div class="analytics-card__header">
+                    <div>
+                        <span class="analytics-card__eyebrow">Daily activity</span>
+                        <h4>Watch history</h4>
+                    </div>
+                    <span class="calendar-card__period">
+                        {{ startDate | date:'MMM' }} {{ startDate.getFullYear() }} - {{ endDate | date:'MMM' }} {{ endDate.getFullYear() }}
+                    </span>
+                </div>
+                <div class="calendar-scroll" aria-label="365-day watch history">
+                    <div class="calendar-scroll__labels">
+                        <div class="calendar-stats__days">
+                            <div class="calendar-stats__day">Mon</div>
+                            <div class="calendar-stats__day">Tue</div>
+                            <div class="calendar-stats__day">Wed</div>
+                            <div class="calendar-stats__day">Thu</div>
+                            <div class="calendar-stats__day">Fri</div>
+                            <div class="calendar-stats__day">Sat</div>
+                            <div class="calendar-stats__day">Sun</div>
+                        </div>
+                    </div>
+                    <div class="calendar-scroll__content">
+                        <div class="calendar-stats__months">
+                            @for (month of calendarItemsMonths; track month) {
+                                <div class="calendar-stats__month">{{ month | date:'MMM' }}</div>
+                            }
+                        </div>
+                        <div class="calendar-stats">
+                            @for (media of calendarItems; track media) {
+                                <div class="calendar-stats__cell" [class.is-hovered]="hoveredCalendarItem?.key === media.key"
+                                     style="background:rgba(148, 90, 245, {{ media.value > 0 ? generateCalenderItemColour(media.value) : '' }})"
+                                     [attr.aria-label]="(media.key | date:'EEE, MMM d, y') + ': ' + media.value + (media.value === 1 ? ' watch' : ' watches')"
+                                     tabindex="0" role="img"
+                                     (mouseenter)="selectCalendarItem(media)" (mouseleave)="clearCalendarItem()"
+                                     (focus)="selectCalendarItem(media)" (blur)="clearCalendarItem()"></div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="calendar-card__detail" aria-live="polite">
+                    @if (hoveredCalendarItem) {
+                        <strong>{{ hoveredCalendarItem.key | date:'EEE, MMM d, y' }}</strong>
+                        <span>{{ hoveredCalendarItem.value }} {{ hoveredCalendarItem.value === 1 ? 'watch' : 'watches' }} recorded on this day.</span>
+                    } @else {
+                        <span>Hover a day to see its watch total.</span>
+                    }
+                </div>
+                <div class="calendar-card__legend">
+                    <div>0 <div class="calendar-stats__cell" style="background:rgba(255, 255, 255, 0.05)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.25)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.5)"></div></div>
+                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.75)"></div></div>
+                    <div>{{ calendarMaxValue }} <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 1)"></div></div>
+                </div>
+            </section>
+        }
+
         @if (!statsLoading) {
             <div class="analytics-grid u-mt-3">
                 <section class="analytics-card genre-card">
@@ -164,52 +223,6 @@
                     </div>
                 </section>
             </div>
-        }
-        @if (!calendarStatsLoading) {
-            <section class="analytics-card calendar-card u-mt-3">
-                <div class="analytics-card__header">
-                    <div>
-                        <span class="analytics-card__eyebrow">Daily activity</span>
-                        <h4>Watch history</h4>
-                    </div>
-                    <span class="calendar-card__period">
-                        {{ startDate | date:'MMM' }} {{ startDate.getFullYear() }} - {{ endDate | date:'MMM' }} {{ endDate.getFullYear() }}
-                    </span>
-                </div>
-                <div class="calendar-scroll" aria-label="365-day watch history">
-                    <div class="calendar-scroll__labels">
-                        <div class="calendar-stats__days">
-                            <div class="calendar-stats__day">Mon</div>
-                            <div class="calendar-stats__day">Tue</div>
-                            <div class="calendar-stats__day">Wed</div>
-                            <div class="calendar-stats__day">Thu</div>
-                            <div class="calendar-stats__day">Fri</div>
-                            <div class="calendar-stats__day">Sat</div>
-                            <div class="calendar-stats__day">Sun</div>
-                        </div>
-                    </div>
-                    <div class="calendar-scroll__content">
-                        <div class="calendar-stats__months">
-                            @for (month of calendarItemsMonths; track month) {
-                                <div class="calendar-stats__month">{{ month | date:'MMM' }}</div>
-                            }
-                        </div>
-                        <div class="calendar-stats">
-                            @for (media of calendarItems; track media) {
-                                <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, {{ media.value > 0 ? generateCalenderItemColour(media.value) : '' }})"
-                                     title="{{ media.key }} - {{ media.value }}"></div>
-                            }
-                        </div>
-                    </div>
-                </div>
-                <div class="calendar-card__legend">
-                    <div>0 <div class="calendar-stats__cell" style="background:rgba(255, 255, 255, 0.05)"></div></div>
-                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.25)"></div></div>
-                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.5)"></div></div>
-                    <div><div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 0.75)"></div></div>
-                    <div>{{ calendarMaxValue }} <div class="calendar-stats__cell" style="background:rgba(148, 90, 245, 1)"></div></div>
-                </div>
-            </section>
         }
     </div>
 </div>

--- a/src/pages/statistics-page/statistics-page.component.scss
+++ b/src/pages/statistics-page/statistics-page.component.scss
@@ -123,10 +123,13 @@
             border-radius: 2.5px;
             border: 1px solid transparent;
             cursor: pointer;
+            outline: none;
+            transition: border-color var(--transition-speed) ease, filter var(--transition-speed) ease;
 
-            &:hover {
+            &:hover, &:focus, &.is-hovered {
                 background: rgba(255, 255, 255, 0.05);
-                border: 1px solid rgba(255, 255, 255, 0.25);
+                border: 1px solid rgba(255, 255, 255, 0.35);
+                filter: brightness(1.2) drop-shadow(0 0 4px rgba(255, 255, 255, .24));
             }
         }
 

--- a/src/pages/statistics-page/statistics-page.component.ts
+++ b/src/pages/statistics-page/statistics-page.component.ts
@@ -57,6 +57,7 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
     public startDate: Date = new Date();
     public endDate: Date = new Date();
     public calendarMaxValue: number = 0;
+    public hoveredCalendarItem: { key: string; value: number } | null = null;
     public genreSlices: IGenreSlice[] = [];
     public hoveredGenre: IGenreSlice | null = null;
     public timeOfDayChart: ILineChart = this.emptyLineChart();
@@ -139,8 +140,13 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
 
             if (event.watchedAt >= yearAgo && event.watchedAt <= now) {
                 timeCounts[event.watchedAt.getHours()]++;
-                weekdayCounts[(event.watchedAt.getDay() + 6) % 7]++;
             }
+        }
+
+        for (const item of this.calendarItems) {
+            const [year, month, day] = item.key.split('-').map(Number);
+            const calendarDate = new Date(year, month - 1, day);
+            weekdayCounts[(calendarDate.getDay() + 6) % 7] += item.value;
         }
 
         this.genreSlices = this.createGenreSlices(genreCounts);
@@ -207,6 +213,14 @@ export class StatisticsPageComponent implements OnInit, OnDestroy {
 
     public clearChartPoint(): void {
         this.hoveredChartPoint = null;
+    }
+
+    public selectCalendarItem(item: { key: string; value: number }): void {
+        this.hoveredCalendarItem = item;
+    }
+
+    public clearCalendarItem(): void {
+        this.hoveredCalendarItem = null;
     }
 
     private polarPoint(centerX: number, centerY: number, radius: number, angle: number): { x: number; y: number } {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -641,6 +641,18 @@ hr {
             text-align: right;
         }
 
+        &__detail {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+            min-height: 34px;
+            margin-top: 12px;
+            color: var(--text-color-alt);
+            font-size: .7rem;
+
+            strong { color: var(--text-color); font-size: .76rem; }
+        }
+
         &__legend {
             display: flex;
             align-items: center;
@@ -665,6 +677,7 @@ hr {
         width: 100%;
         min-width: 0;
         overflow-x: auto;
+        overflow-y: hidden;
         overscroll-behavior-inline: contain;
         scrollbar-color: rgba(151, 116, 245, .5) transparent;
 


### PR DESCRIPTION
## Summary

- Add the same hover and keyboard-focus feedback to each 365-day activity cell.
- Show the selected date and its watch total in the Daily activity detail panel.
- Highlight the selected calendar cell and keep the existing horizontal layout.
- Explicitly hide vertical overflow so the Daily activity graph scrolls horizontally only.
- Move Daily activity directly below the summary numbers and above the pie/line charts.
- Derive weekday totals from backend calendar dates so Sunday and Monday remain aligned and visible.

## Validation

- `npm run build` ✅
- `npx tsc --noEmit -p tsconfig.app.json` ✅
- `git diff --check` ✅
- Existing Sass deprecation and bundle/component budget warnings remain.
- Browser visual validation was unavailable because no browser session could be initialized.

This pull request was created by an AI agent (OpenHands) on behalf of the user.